### PR TITLE
Add Community Partner status for KCD Suisse Romande 2025

### DIFF
--- a/policies/3_community-partners.md
+++ b/policies/3_community-partners.md
@@ -1,0 +1,51 @@
+# KCD Suisse Romande — Community Partner
+
+This document describes a “Community Partner” status that applies to the KCD Suisse Romande conference as a one-off event, 
+and to the partnership with the Association Cloud Native Suisse Romande (the Association).
+
+## Purpose
+
+The Community Partner program connects local tech meetups, associations, and communities with the KCD Suisse Romande conference
+nd other events organized by the Association.
+The goal is to strengthen the regional cloud-native and FOSS ecosystems through shared visibility and cross-promotion,
+in line with the association’s [goals](https://cloud-native-romandy.ch/governance/association/charter/#goal).
+
+This collaboration is non-commercial and does not involve financial exchange.
+
+## Who Can Be a Community Partner
+
+The program and the conference partner status focus on non-commercial community groups based in or operating in the Suisse Romande region,
+other regions of Switzerland, or neighboring regions of France, with active cross-border participation.
+Other organizations can also become community partners if deemed beneficial to the local ecosystem.
+
+No exclusivity is required. Groups may collaborate with any other organizations or events.
+
+## What We Provide
+
+- KCD Suisse Romande 2025 Community ticket pricing for partner members.
+  A unique promotional code for the partner group to distribute to their members:  
+  - 0 CHF – Volunteer rate  
+  - 99 CHF – Conference Only (Dec 05\)  
+  - 149 CHF – Conference Day \+ Workshops (Dec 04 \+ 05\)  
+- Visibility on the KCD Suisse Romande website and in event communications as a Community Partner.  
+- Option to share relevant announcements, CFP calls, or volunteer opportunities through the association’s channels \- site, social media, newsletter, etc.  
+- Information exchange about potential speakers and sponsors.
+
+## What the Community Partner is Expected To
+
+- Operate in good faith, in the best interest of the local cloud-native ecosystem in the region.  
+- Promote KCD Suisse Romande to their community at least once before, during, and after the event (e.g., meetup announcement, Slack/Discord post, newsletter mention).  
+- Allow KCD Suisse Romande to share relevant partner announcements in return (e.g., meetup events, calls for speakers), in the partner’s channels.  
+- Maintain communication through a designated organizer contact.
+
+## What Is Not Part of This Partnership
+
+In this partnership, there are no financial commitments in either direction.
+Partners make no commitments for sponsorship, booth, vendor, or other event participation.
+
+Neither party is required to provide speakers, send representatives, or host events.
+
+## Logistics
+
+Currently, there is no formal Community Partner agreement to be signed between the parties.
+Either party can terminate the Community Partner status at any time.


### PR DESCRIPTION
This document outlines the Community Partner program for KCD Suisse Romande, detailing the purpose, eligibility, benefits, expectations, and logistics of the partnership.

The document was initially reviewed by the association members

Related to https://github.com/cloud-native-suisse-romande/governance/issues/13, but focused more on the local associations and meetups
