### PR TITLE
Add a list of the community partners as a separate page, Make the org memberships status clear

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,10 @@
     "cSpell.words": [
         "CERN",
         "CNCF",
+        "FOSS",
         "Neuchâtel",
         "Romande",
+        "Romandy",
         "Suisse Romande"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -16,5 +16,7 @@ See the [Association Members page](./association/members.md) for the list of ind
 ## Governance Documents
 
 - [Association Charter](./association/charter.md)
+- [Members](./association/members.md)
+- [Community Partners and Event Sponsors](./association/partners.md)
 - [Code of Conduct](./bylaws/CODE_OF_CONDUCT.md)
 - [Privacy Policy](./policies/1_privacy-policy.md)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ See the [Association Members page](./association/members.md) for the list of ind
 
 - [Association Charter](./association/charter.md)
 - [Members](./association/members.md)
-- [Community Partners and Event Sponsors](./association/partners.md)
+- [Community Partners](./association/partners.md)
 - [Code of Conduct](./bylaws/CODE_OF_CONDUCT.md)
 - [Privacy Policy](./policies/1_privacy-policy.md)
+
+## Additional information
+
+- [Event Sponsorships](./association/sponsors.md)
+- [Donations](./association/donations.md)

--- a/association/donations.md
+++ b/association/donations.md
@@ -1,16 +1,17 @@
 # Donations
 
 Donations are always appreciated!
-  
-The association does not have membership fees and, to operate, we use 
-voluntary donations from association members and supporters.
-Once we have events like [KCD](https://cloud-native-romandy.ch/events/kcd/), 
-we will use all profits to support the association and events.
+
+## How we use your donations
+
+The association does not have membership fees.
+To operate, we use [event sponsorships](./sponsors.md), voluntary donations from association members and supporters.
+We will use all additional donations to support the association operations and local events in Suisse Romande.
 
 ## How to donate
 
 Currently you can make a donation by a direct bank transfer.
-In the future, we plan to have a stripe account and GitHub Sponsoors, too.
+In the future, we plan to have a stripe account and GitHub Sponsors, too.
                                
 ### Bank Account
 

--- a/association/members.md
+++ b/association/members.md
@@ -1,6 +1,6 @@
 # Cloud Native Suisse Romande - Association Members
 
-This page lists individual and organization members who have joined the association.
+This page lists individuals who have joined the association as members with voting rights.
 
 ## Individual Members
 
@@ -11,11 +11,6 @@ This page lists individual and organization members who have joined the associat
 * [Raphaël Pinson](https://github.com/raphink)
 * [Thierry Predhom](https://github.com/tpredhom)
 
-
-## Organization Members
-
-Coming Soon!
-
 ## Join the Association
 
 Every active contributor to the Cloud Native Computing ecosystem in the region is welcome to join the association.
@@ -23,3 +18,11 @@ There is no membership fee, the membership is based on the contributions to the 
 
 * [Membership Information in the charter](./charter.md#membership)
 * [Membership Process](../policies/2_membership-process.md)
+
+## Organization Members
+
+We welcome local non-profit organizations to join as [community partners](./partners.md).
+Organizations can also [sponsor](./partners.md#event-sponsorships) some of our community events,
+including KCD Suisse Romande.
+
+No organization memberships are planned so far in the association.

--- a/association/members.md
+++ b/association/members.md
@@ -22,7 +22,7 @@ There is no membership fee, the membership is based on the contributions to the 
 ## Organization Members
 
 We welcome local non-profit organizations to join as [community partners](./partners.md).
-Organizations can also [sponsor](./partners.md#event-sponsorships) some of our community events,
-including KCD Suisse Romande.
+Organizations can also [sponsor](./sponsors.md) some of our community events,
+including the KCD Suisse Romande conference.
 
 No organization memberships are planned so far in the association.

--- a/association/partners.md
+++ b/association/partners.md
@@ -27,4 +27,4 @@ Interested in joining as a community partner? See the program details and expect
 At the moment, there is no established partnership program for commercial organizations.
 However, we have [event sponsorships](./sponsors.md) and accept [donations](./donations.md) from
 commercial organizations.
-We are also open to other ideas that help to strengthen the local cloud native community and the ecosystem..
+We are also open to other ideas that help to strengthen the local cloud native community and the ecosystem.

--- a/association/partners.md
+++ b/association/partners.md
@@ -1,0 +1,35 @@
+# Association Partners
+
+The association partners with the local communities, meetups and non-profits 
+to support the local events and ecosystem.
+We also invite the commercial companies to support our community events as sponsors.
+
+## Community Partners
+
+Our Community Partner program connects local and regional tech communities with KCD Suisse Romande and other association events
+to strengthen the cloud-native and FOSS ecosystem through shared visibility and cross-promotion.
+This collaboration is non-commercial, based on good-faith cooperation,
+and designed to help communities support each other without financial commitments.
+
+The following organizations are our community partners:
+
+* [Cloud Native Suisse Romande](http://cloud-native-romandy.ch/)
+* [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io/)
+* [DevOpsDays Geneva](https://devopsdays-geneva.ch/)
+* [Silicon Chalet](https://www.meetup.com/silicon-chalet/)
+* [Bern Cloud Native Community](https://cloudnativeday.ch/)
+* [Cloud Native Zurich](https://cloudnativezurich.ch/)
+
+Interested in joining as a community partner? See the program details and expectations on the [Community Partner policy](../policies/3_community-partners.md).
+
+## Event Sponsorships
+
+For some of our [events](https://cloud-native-romandy.ch/events/),
+including Kubernetes Community Days (KCD) Suisse Romande,
+we also invite local commercial organizations to join as event sponsors.
+See the event pages for more info.
+
+- [KCD Suisse Romande 2025 Sponsors](https://github.com/cloud-native-suisse-romande/kcd-suisse-romande-2025/blob/main/sponsors.md)
+- [KCD Suisse Romande 2026 Sponsors](https://github.com/cloud-native-suisse-romande/kcd-suisse-romande-2026/blob/main/sponsors.md)
+
+

--- a/association/partners.md
+++ b/association/partners.md
@@ -22,14 +22,9 @@ The following organizations are our community partners:
 
 Interested in joining as a community partner? See the program details and expectations on the [Community Partner policy](../policies/3_community-partners.md).
 
-## Event Sponsorships
+## Partnerships with Commercial Organizations
 
-For some of our [events](https://cloud-native-romandy.ch/events/),
-including Kubernetes Community Days (KCD) Suisse Romande,
-we also invite local commercial organizations to join as event sponsors.
-See the event pages for more info.
-
-- [KCD Suisse Romande 2025 Sponsors](https://github.com/cloud-native-suisse-romande/kcd-suisse-romande-2025/blob/main/sponsors.md)
-- [KCD Suisse Romande 2026 Sponsors](https://github.com/cloud-native-suisse-romande/kcd-suisse-romande-2026/blob/main/sponsors.md)
-
-
+At the moment, there is no established partnership program for commercial organizations.
+However, we have [event sponsorships](./sponsors.md) and accept [donations](./donations.md) from
+commercial organizations.
+We are also open to other ideas that help to strengthen the local cloud native community and the ecosystem..

--- a/association/sponsors.md
+++ b/association/sponsors.md
@@ -1,0 +1,16 @@
+# Sponsorships
+
+## Event Sponsorships
+
+For some of our [events](https://cloud-native-romandy.ch/events/),
+including Kubernetes Community Days (KCD) Suisse Romande,
+we also invite local commercial organizations to join as event sponsors.
+See the event pages for more info.
+
+- [KCD Suisse Romande 2025 Sponsors](https://github.com/cloud-native-suisse-romande/kcd-suisse-romande-2025/blob/main/sponsors.md)
+- [KCD Suisse Romande 2026 Sponsors](https://github.com/cloud-native-suisse-romande/kcd-suisse-romande-2026/blob/main/sponsors.md)
+
+## Donations
+
+The association accepts donations from individuals and companies.
+See [this page](./donations.md) for more info.

--- a/policies/3_community-partners.md
+++ b/policies/3_community-partners.md
@@ -49,3 +49,7 @@ Neither party is required to provide speakers, send representatives, or host eve
 
 Currently, there is no formal Community Partner agreement to be signed between the parties.
 Either party can terminate the Community Partner status at any time.
+
+## References
+
+- [List of our Community Partners](../association/partners.md)


### PR DESCRIPTION
This change adds an explicit list of community partners.

This also contributes to #13 and makes the current status of organization memberships explicit. At the moment, there are no plans for other types of organization memberships. So we will put it like that and invite community partners and event sponsors.

Closes #13 
